### PR TITLE
Fix for rename crate rust-crypto to crypto

### DIFF
--- a/src/rustic_io.rs
+++ b/src/rustic_io.rs
@@ -26,7 +26,7 @@
 
 
 extern crate serialize;
-extern crate "rust-crypto" as rust_crypto;
+extern crate "crypto" as rust_crypto;
 
 use std::str;
 use std::io::{TcpListener, TcpStream};


### PR DESCRIPTION
The name of rust-crypto crate was changed to crypto.
This commit fixes issues with new crate name.
